### PR TITLE
Make API calls asynchronous

### DIFF
--- a/plugin/lib/WebService/Pandora/Method.pm
+++ b/plugin/lib/WebService/Pandora/Method.pm
@@ -7,8 +7,6 @@ use WebService::Pandora::Cryptor;
 
 use URI;
 use JSON;
-use HTTP::Request;
-use LWP::UserAgent;
 use Data::Dumper;
 
 ### constructor ###
@@ -36,9 +34,6 @@ sub new {
 
     bless( $self, $class );
 
-    # create and store user agent object
-    $self->{'ua'} = LWP::UserAgent->new( timeout => $self->{'timeout'} );
-
     # create and store json object
     $self->{'json'} = JSON->new();
 
@@ -60,12 +55,12 @@ sub error {
 
 sub execute {
 
-    my ( $self ) = @_;
+    my ( $self, $cb ) = @_;
 
     # make sure both name and host were given
     if ( !defined( $self->{'name'} ) || !defined( $self->{'host'} ) ) {
-
         $self->error( 'Both the name and host must be provided to the constructor.' );
+        $cb->();
         return;
     }
 
@@ -73,13 +68,11 @@ sub execute {
     my $json_data = {};
 
     if ( defined( $self->{'userAuthToken'} ) ) {
-
         $json_data->{'userAuthToken'} = $self->{'userAuthToken'};
     }
 
     if ( defined( $self->{'syncTime'} ) ) {
-
-        $json_data->{'syncTime'} = time() + $self->{'syncTime'};
+        $json_data->{'syncTime'} = int( $self->{'syncTime'} );
     }
 
     # merge the two required params with the additional user-supplied args
@@ -90,13 +83,12 @@ sub execute {
 
     # encrypt it, if needed
     if ( $self->{'encrypt'} ) {
-
         $json_data = $self->{'cryptor'}->encrypt( $json_data );
 
         # detect error decrypting
         if ( !defined( $json_data ) ) {
-
             $self->error( 'An error occurred encrypting our JSON data: ' . $self->{'cryptor'}->error() );
+            $cb->();
             return;
         }
     }
@@ -115,25 +107,21 @@ sub execute {
 
     # set user_auth_token if provided
     if ( defined( $self->{'userAuthToken'} ) ) {
-
         push( @$url_params, 'auth_token' => $self->{'userAuthToken'} );
     }
 
     # set partner_auth_token if provided and user_auth_token was not
     elsif ( defined( $self->{'partnerAuthToken'} ) ) {
-
         push( @$url_params, 'auth_token' => $self->{'partnerAuthToken'} );
     }
 
     # set partner_id if provided
     if ( defined( $self->{'partnerId'} ) ) {
-
         push( @$url_params, 'partner_id' => $self->{'partnerId'} );
     }
 
     # set user_id if provided
     if ( defined( $self->{'userId'} ) ) {
-
         push( @$url_params, 'user_id' => $self->{'userId'} );
     }
 
@@ -141,43 +129,28 @@ sub execute {
     $uri->query_form( $url_params );
 
     # create and store the POST request accordingly
-    my $request = HTTP::Request->new( 'POST', $uri );
+    my $http = Slim::Networking::SimpleAsyncHTTP->new(
+        sub {
+            my $response = shift;
+            my $json_data = $self->{'json'}->decode( $response->content );
 
-    # json data is the POST content
-    $request->content( $json_data );
-
-    # issue the HTTP request
-    my $response = $self->{'ua'}->request( $request );
-
-    # handle request error
-    if ( !$response->is_success() ) {
-
-        $self->error( $response->status_line() );
-        return;
-    }
-
-    # decode the raw content of the response
-    my $content = $response->decoded_content();
-
-    # decode the JSON content
-    $json_data = $self->{'json'}->decode( $content );
-
-    # handle pandora error
-    if ( $json_data->{'stat'} ne 'ok' ) {
-
-        $self->error( {
-          'apiCode' => $json_data->{'code'},
-          'apiMessage' => $json_data->{'message'},
-          'message' => "$self->{'name'} error $json_data->{'code'}: $json_data->{'message'}",
-        } );
-        return;
-    }
-
-    # return all result data, if any exists
-    return $json_data->{'result'} if ( defined( $json_data->{'result'} ) );
-
-    # otherwise just return a true value to indicate success
-    return 1;
+            # handle pandora error
+            if ( $json_data->{'stat'} ne 'ok' ) {
+                $self->error( "$self->{'name'} error $json_data->{'code'}: $json_data->{'message'}" );
+            }
+            my $result = defined($json_data->{'result'}) ? $json_data->{'result'} : undef;
+            $cb->($result);
+        },
+        sub {
+            my ($req, $error) = @_;
+            $self->error( $error );
+            $cb->();
+        },
+        {
+            timeout => $self->{timeout},
+        }
+    );
+    $http->post($uri, $json_data);
 }
 
 1;

--- a/plugin/lib/WebService/Pandora/Partner.pm
+++ b/plugin/lib/WebService/Pandora/Partner.pm
@@ -45,7 +45,7 @@ sub error {
 
 sub login {
 
-    my ( $self ) = @_;
+    my ( $self, $cb ) = @_;
 
     # make sure all arguments are given
     if ( !defined( $self->{'username'} ) ||
@@ -56,6 +56,7 @@ sub login {
          !defined( $self->{'host'} ) ) {
 
         $self->error( 'The username, password, deviceModel, encryption_key, decryption_key, and host must all be provided to the constructor.' );
+        $self->{'cb'}->();
         return;
     }
 
@@ -69,16 +70,15 @@ sub login {
                                                               'deviceModel' => $self->{'deviceModel'},
                                                               'version' => "5"} );
 
-    my $result = $method->execute();
-
-    # detect error
-    if ( !$result ) {
-
-        $self->error( $method->error() );
-        return;
-    }
-
-    return $result;
+    $method->execute(
+        sub {
+            my ($res) = @_;
+            if ($method->error) {
+                $self->error( $method->error )
+            }
+            $cb->($res);
+        }
+    );
 }
 
 1;

--- a/plugin/lib/WebService/Pandora/Partner/AIR.pm
+++ b/plugin/lib/WebService/Pandora/Partner/AIR.pm
@@ -20,7 +20,7 @@ sub new {
 				   decryption_key => 'U#IO$RZPAB%VX2',
 				   encryption_key => '2%3WCL*JU$MP]4',
 				   host => 'internal-tuner.pandora.com' );
-    
+
     return $self;
 }
 


### PR DESCRIPTION
Converts synchronous HTTP::Request requests to asynchronous Slim::Networking::SimpleAsyncHTTP requests

Only the WebService::Pandora::login, WebService::Pandora::getStationList, WebService::Pandora::getStation, and WebService::Pandora::getPlaylist methods have been updated to work with the asynchronous call and now require a callback code ref