### PR TITLE
Use REST API for station list and allow sorting

### DIFF
--- a/plugin/HTML/EN/plugins/Pyrrha/settings/basic.html
+++ b/plugin/HTML/EN/plugins/Pyrrha/settings/basic.html
@@ -14,16 +14,30 @@
 	[% END %]
 
 	[% WRAPPER setting title="SETUP_PASSWORD" desc="" %]
-	<p>
 		<input type="password" class="stdedit" name="pref_password" id="password" value="[% prefs.pref_password | html %]" size="40">
-	</p>
+	[% END %]
+
+	[% WRAPPER setting title="PLUGIN_PYRRHA_STATION_SORT_ORDER" desc="" %]
+		<select class="stdedit" name="pref_stationSortOrder" id="pref_stationSortOrder">
+			[% FOREACH option = {
+				PLUGIN_PYRRHA_STATION_SORT_AZ => 'name',
+				PLUGIN_PYRRHA_STATION_SORT_CREATED => 'dateCreated',
+				PLUGIN_PYRRHA_STATION_SORT_PLAYED => 'lastPlayed',
+				PLUGIN_PYRRHA_STATION_SORT_LISTENED => 'totalPlayTime',
+			} %]
+			<option [% IF prefs.pref_stationSortOrder == option.value %]selected [% END %]value="[% option.value %]">[% option.key | string %]</option>
+			[%- END -%]
+		</select>
+	[% END %]
+
+	[% WRAPPER setting title="PLUGIN_PYRRHA_DISABLE_QUICKMIX" desc="" %]
+		<input type="checkbox" class="stdedit" name="pref_disableQuickMix" id="disableQuickMix" [% IF prefs.pref_disableQuickMix %]checked="checked" [% END %] value="1">
+		<label for="disableQuickMix">[% "PLUGIN_PYRRHA_DISABLE_QUICKMIX_DESC" | string %]</label>
 	[% END %]
 
 	[% WRAPPER setting title="PLUGIN_PYRRHA_MATERIAL_SKIN" desc="" %]
-	<p>
 		<input type="checkbox" class="stdedit" name="pref_forceNonMaterialIcon" id="forceNonMaterialIcon" [% IF prefs.pref_forceNonMaterialIcon %]checked="checked" [% END %] value="1">
 		<label for="forceNonMaterialIcon">[% "PLUGIN_PYRRHA_FORCE_NONMATERIAL_APPICON" | string %]</label>
-	</p>
 	[% END %]
 
 [% PROCESS settings/footer.html %]

--- a/plugin/Plugin.pm
+++ b/plugin/Plugin.pm
@@ -8,7 +8,7 @@ use base qw(Slim::Plugin::OPMLBased);
 use Digest::MD5 qw(md5_hex);
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
-use Plugins::Pyrrha::Utils qw(getStationList);
+use Plugins::Pyrrha::Utils qw(getStationList getStationArtUrl);
 
 sub getDisplayName () {
   return 'PLUGIN_PYRRHA_MODULE_NAME';
@@ -74,7 +74,7 @@ sub handleFeed {
     unshift @sorted_stations, @quickmix;
     foreach my $station ( @sorted_stations ) {
       my $stationId = $station->{'stationId'};
-      my $artUrl = $station->{'art'}->[0]->{'url'};
+      my $artUrl = getStationArtUrl($station);
       push @$items, {
         'name'  => $station->{'name'},
         'type'  => 'audio',

--- a/plugin/Plugin.pm
+++ b/plugin/Plugin.pm
@@ -37,11 +37,46 @@ sub handleFeed {
     my ($stations) = @_;
     my $username = $prefs->get('username');
     my $usernameDigest = md5_hex($username);
-    foreach my $station ( @$stations ) {
+    my $stationSortKey = $prefs->get('stationSortOrder');
+    my $stationSortMethod;
+    if ($stationSortKey eq 'name') {
+      $stationSortMethod = sub {
+        (exists $a->{$stationSortKey} && $a->{$stationSortKey} || '') cmp (exists $b->{$stationSortKey} && $b->{$stationSortKey} || '');
+      };
+    }
+    elsif ($stationSortKey eq 'dateCreated') {
+      $stationSortMethod = sub {
+        (exists $b->{$stationSortKey} && $b->{$stationSortKey} || '') cmp (exists $a->{$stationSortKey} && $a->{$stationSortKey} || '')
+      };
+    }
+    elsif ($stationSortKey eq 'lastPlayed') {
+      $stationSortMethod = sub {
+        (exists $b->{$stationSortKey} && $b->{$stationSortKey} || '') cmp (exists $a->{$stationSortKey} && $a->{$stationSortKey} || '')
+      };
+    }
+    elsif ($stationSortKey eq 'totalPlayTime') {
+      $stationSortMethod = sub {
+        (exists $b->{$stationSortKey} && $b->{$stationSortKey} || 0) <=> (exists $a->{$stationSortKey} && $a->{$stationSortKey} || 0)
+      };
+    }
+    else {
+      $log->error("Invalid stationSortOrder ${stationSortKey}");
+      $callback->();
+    }
+    $log->debug("Sorting stations by $stationSortKey");
+    my @quickmix;
+    my @sorted_stations = @$stations;
+    # Temporarily exclude quickmix station from sort to keep at top
+    unless ($prefs->get('disableQuickMix')) {
+      push(@quickmix, shift @sorted_stations);
+    }
+    @sorted_stations = sort $stationSortMethod @sorted_stations;
+    unshift @sorted_stations, @quickmix;
+    foreach my $station ( @sorted_stations ) {
       my $stationId = $station->{'stationId'};
-      my $artUrl = $station->{'artUrl'};
+      my $artUrl = $station->{'art'}->[0]->{'url'};
       push @$items, {
-        'name'  => $station->{'stationName'},
+        'name'  => $station->{'name'},
         'type'  => 'audio',
         'url'   => "pyrrha://$usernameDigest/$stationId.mp3",
         'image' => $artUrl ? $artUrl : 'plugins/Pyrrha/images/icon_svg.png',
@@ -69,6 +104,10 @@ sub initPlugin {
   Slim::Player::ProtocolHandlers->registerHandler(
     pyrrha => 'Plugins::Pyrrha::ProtocolHandler'
   );
+
+  $prefs->init({
+    stationSortOrder => 'lastPlayed',
+  });
 
   if ( main::WEBUI ) {
     require Plugins::Pyrrha::Settings;

--- a/plugin/Settings.pm
+++ b/plugin/Settings.pm
@@ -16,7 +16,7 @@ sub page {
 }
 
 sub prefs {
-  return ($prefs, 'username', 'password', 'forceNonMaterialIcon');
+  return ($prefs, 'username', 'password', 'stationSortOrder', 'disableQuickMix', 'forceNonMaterialIcon');
 }
 
 sub handler {

--- a/plugin/Utils.pm
+++ b/plugin/Utils.pm
@@ -24,6 +24,7 @@ my $prefs = preferences( 'plugin.pyrrha' );
 
 
 my %cache = ();
+my $json = JSON->new->utf8;
 
 
 my $WEBSVC_LIFETIME = (60 * 60 * 4) - (60 * 2);  # 4 hrs - 2 min grace
@@ -248,7 +249,7 @@ sub _restCsrfCallback {
     my $http = Slim::Networking::SimpleAsyncHTTP->new(
       sub {
         my $response = shift;
-        my $json = JSON->new->decode($response->content);
+        my $json = $json->decode($response->content);
         $successCb->(result => $json, passthrough => $passthrough);
       },
       sub {
@@ -262,7 +263,7 @@ sub _restCsrfCallback {
       'X-CsrfToken' => $csrftoken,
       'X-AuthToken' => $websvc->{'userAuthToken'},
       'Content-Type' => 'application/json;charset=utf-8',
-      JSON->new->encode($args),
+      $json->encode($args),
     );
   };
   getWebService($withWebsvc, sub { $errorCb->(shift, $passthrough); });

--- a/plugin/Utils.pm
+++ b/plugin/Utils.pm
@@ -6,9 +6,13 @@ use Exporter 'import';
 our @EXPORT_OK = qw(getWebService getStationList getPlaylist);
 
 use Slim::Utils::Prefs;
+use Slim::Networking::SimpleAsyncHTTP;
+use Slim::Networking::Async::HTTP;
+use URI;
 use JSON;
 use WebService::Pandora;
 use WebService::Pandora::Partner::AIR;
+use Data::Dumper;
 
 my $log = Slim::Utils::Log->addLogCategory({
   category     => 'plugin.pyrrha',
@@ -24,7 +28,7 @@ my %cache = ();
 
 my $WEBSVC_LIFETIME = (60 * 60 * 4) - (60 * 2);  # 4 hrs - 2 min grace
 my $STATIONLIST_LIFETIME = 60 * 20;              # 20 min
-
+my $STATIONLIST_PAGESIZE = 250;                  # How many stations to retrieve at a time
 
 sub getWebService {
   my ($successCb, $errorCb) = @_;
@@ -62,10 +66,10 @@ sub getWebService {
   });
 }
 
-
 sub getStationList {
   my ($successCb, $errorCb, %args) = @_;
   my $noRefresh = $args{'noRefresh'};
+  my @stations;
 
   my $websvc = $cache{'webService'};
   my $stationList = $cache{'stationList'};
@@ -79,69 +83,94 @@ sub getStationList {
     return;
   }
 
-  my $withWebsvc = sub {
-    my ($websvc) = @_;
-    $log->info('fetching station list');
-    $websvc->getStationList(sub {
-      my (%r) = @_;
-      my ($result, $error) = @r{'result', 'error'};
-      if ($result) {
-        my $stationList = {
-          expiresAt => time() + $STATIONLIST_LIFETIME,
-          stations  => $result->{'stations'},
-        };
-        $cache{'stationList'} = $stationList;
-        $successCb->($stationList->{'stations'}, $websvc);
-      }
-      else {
-        if (ref $error eq 'HASH') {
-          if ($error->{'apiCode'} == 1001) {
-            # auth token expired, clear our cached credentials
-            $log->info('auth token expired, clearing cache');
-            %cache = ();
-          }
-          $error = $error->{'message'}
-        }
-        $log->error($error);
-        $errorCb->("Error getting station list ($error)");
-      }
+  # Skip fetching QuickMix/Shuffle station if desired
+  if ($prefs->get('disableQuickMix')) {
+    getRestStationList({
+      stations  => \@stations,
+      successCb => $successCb,
+      errorCb   => $errorCb,
+    });
+  }
+  else {
+    getRestQuickMix({
+      stations  => \@stations,
+      successCb => $successCb,
+      errorCb   => $errorCb,
+    });
+  }
+}
+
+sub getRestStationList {
+  _rest(
+    'v1/station/getStations',
+    {
+      pageSize => $STATIONLIST_PAGESIZE,
     },
-      includeStationArtUrl => JSON::true(),
-      returnAllStations => JSON::true(),
+    \&restStationCallback,
+    \&restErrorCallback,
+    @_,
+  );
+}
+
+sub restStationCallback {
+  my (%response) = @_;
+  my $stations = $response{'passthrough'}->{'stations'};
+  $log->debug("Retrieved " . scalar(@{$response{'result'}->{'stations'}}) . " stations");
+  $log->debug("Station IDs: " . join(', ', map { $_->{'stationId'} } @{$response{'result'}->{'stations'}}));
+  my $total_stations = $response{'result'}->{'totalStations'};
+  $log->debug("Total stations: ${total_stations}");
+  $log->debug(Dumper($response{'result'}->{'stations'}->[0]));
+  push(@$stations, @{$response{'result'}->{'stations'}});
+  $log->debug("Total retrieved stations: " . scalar(@$stations));
+  if (scalar(@$stations) < $total_stations) {
+    _rest(
+      'v1/station/getStations',
+      {
+        pageSize   => $STATIONLIST_PAGESIZE,
+        startIndex => scalar(@$stations),
+      },
+      \&restStationCallback,
+      \&restErrorCallback,
+      $response{'passthrough'},
     );
-  };
-
-  my $withoutWebsvc = sub {
-    $log->error(@_);
-    $errorCb->('Unable to connect/login to Pandora');
-  };
-
-  getWebService($withWebsvc, $withoutWebsvc);
+  }
+  else {
+    $log->debug("Retrieved all " . scalar(@$stations) . " stations");
+    $cache{'stationList'} = {
+      expiresAt => time() + $STATIONLIST_LIFETIME,
+      stations  => $stations,
+    };
+    $response{'passthrough'}->{'successCb'}->($stations);
+  }
 }
 
-
-sub getStationToken {
-  my ($stationId, $successCb, $errorCb) = @_;
-
-  my $withStationList = sub {
-    my ($stationList, $websvc) = @_;
-    my ($station) = grep { $stationId == $_->{stationId} } @$stationList;
-    if ($station) {
-      $successCb->($station->{stationToken}, $websvc);
-    }
-    else {
-      $log->error('stationId not found in station list');
-      $errorCb->('Station not found');
-    }
-  };
-
-  my $withoutStationList = sub {
-    $errorCb->(@_);
-  };
-
-  getStationList($withStationList, $withoutStationList, noRefresh => 1);
+sub getRestQuickMix {
+  _rest(
+    'v1/station/shuffle',
+    {},
+    \&restQuickMixCallback,
+    \&restErrorCallback,
+    @_,
+  );
 }
 
+sub restQuickMixCallback {
+  my (%response) = @_;
+  $log->debug("shuffle response: " . Dumper(\%response));
+  my $stations = $response{'passthrough'}->{'stations'};
+  push(@$stations, $response{'result'});
+  getRestStationList({
+    stations  => $stations,
+    successCb => $response{'passthrough'}->{'successCb'},
+    errorCb   => $response{'passthrough'}->{'errorCb'},
+  });
+}
+
+sub restErrorCallback {
+  my ($error, $passthrough) = @_;
+  $log->error($error);
+  $passthrough->{'errorCb'}->($error);
+}
 
 sub getPlaylist {
   my ($stationId, $successCb, $errorCb) = @_;
@@ -150,8 +179,8 @@ sub getPlaylist {
     $errorCb->(@_);
   };
 
-  my $withStationToken = sub {
-    my ($stationToken, $websvc) = @_;
+  my $withWebsvc = sub {
+    my ($websvc) = @_;
     $websvc->getPlaylist(sub {
       my (%r) = @_;
       my ($result, $error) = @r{'result', 'error'};
@@ -172,13 +201,65 @@ sub getPlaylist {
         $errorCb->("Error getting play list ($error)");
       }
     },
-      stationToken => $stationToken
+      stationToken => $stationId
     );
   };
 
-  getStationToken($stationId, $withStationToken, $onError);
+  getWebService($withWebsvc, $onError);
 }
 
+sub _rest {
+  my ($endpoint, $args, $successCb, $errorCb, $passthrough) = @_;
+
+  # Fetch CSRF cookie from www.pandora.com
+  my $uri = URI->new('https://www.pandora.com');
+  my $http = Slim::Networking::SimpleAsyncHTTP->new(
+    sub {
+      _restCsrfCallback->($endpoint, $args, $successCb, $errorCb, $passthrough);
+    },
+    sub {
+      my ($req, $error) = @_;
+      $log->error($error);
+      $errorCb->($error, $passthrough);
+    },
+    {
+      $args,
+    }
+  );
+  $http->head($uri);
+}
+
+sub _restCsrfCallback {
+  my ($endpoint, $args, $successCb, $errorCb, $passthrough) = @_;
+  my $csrftoken = Slim::Networking::Async::HTTP->cookie_jar->get_cookies('.pandora.com', 'csrftoken');
+  unless ($csrftoken) {
+    $errorCb->(result => undef, error => 'Failed to retrieve CSRF token from www.pandora.com');
+    return;
+  }
+  my $uri = URI->new("https://www.pandora.com/api/${endpoint}");
+  my $withWebsvc = sub {
+    my ($websvc) = @_;
+    my $http = Slim::Networking::SimpleAsyncHTTP->new(
+      sub {
+        my $response = shift;
+        my $json = JSON->new->decode($response->content);
+        $successCb->(result => $json, passthrough => $passthrough);
+      },
+      sub {
+        my ($req, $error) = @_;
+        $log->error($error);
+        $errorCb->($error, $passthrough);
+      }
+    );
+    $http->post(
+      $uri,
+      'X-CsrfToken' => $csrftoken,
+      'X-AuthToken' => $websvc->{'userAuthToken'},
+      'Content-Type' => 'application/json;charset=utf-8',
+      JSON->new->encode($args),
+    );
+  };
+  getWebService($withWebsvc, sub { $errorCb->(shift, $passthrough); });
+}
 
 1;
-

--- a/plugin/Utils.pm
+++ b/plugin/Utils.pm
@@ -3,7 +3,7 @@ package Plugins::Pyrrha::Utils;
 use strict;
 
 use Exporter 'import';
-our @EXPORT_OK = qw(getWebService getStationList getPlaylist);
+our @EXPORT_OK = qw(getWebService getStationList getPlaylist getStationArtUrl);
 
 use Slim::Utils::Prefs;
 use Slim::Networking::SimpleAsyncHTTP;
@@ -30,6 +30,7 @@ my $json = JSON->new->utf8;
 my $WEBSVC_LIFETIME = (60 * 60 * 4) - (60 * 2);  # 4 hrs - 2 min grace
 my $STATIONLIST_LIFETIME = 60 * 20;              # 20 min
 my $STATIONLIST_PAGESIZE = 250;                  # How many stations to retrieve at a time
+my $STATIONART_SIZE = 500;                       # Size of station art to use. 90, 130, 500, 640, 1080
 
 sub getWebService {
   my ($successCb, $errorCb) = @_;
@@ -99,6 +100,20 @@ sub getStationList {
       errorCb   => $errorCb,
     });
   }
+}
+
+sub getStationArtUrl {
+  my $station = shift;
+  return unless (
+    $station &&
+    ref $station eq 'HASH' &&
+    ref $station->{'art'} eq 'ARRAY'
+  );
+  for my $art (@{$station->{'art'}}) {
+    return $art->{'url'} if $art->{'size'} == $STATIONART_SIZE;
+  }
+  $log->debug("No station art matching size ${STATIONART_SIZE} found");
+  return $station->{'art'}->[0]->{'url'};
 }
 
 sub getRestStationList {

--- a/plugin/strings.txt
+++ b/plugin/strings.txt
@@ -76,3 +76,24 @@ PLUGIN_PYRRHA_FORCE_NONMATERIAL_APPICON
 
 PLUGIN_PYRRHA_DISCLAIMER
 	EN	<p>This is beta software, currently at a proof-of-concept stage.  <em>Use at your own risk.</em></p> <p>This plugin is not approved by Pyrrha's mother, and as such, its use may not be tolerated. <em>Invite the wrath of the Gods at your own risk.</em></p>
+
+PLUGIN_PYRRHA_STATION_SORT_ORDER
+	EN	Sort order of station list
+
+PLUGIN_PYRRHA_STATION_SORT_AZ
+	EN	A-Z
+
+PLUGIN_PYRRHA_STATION_SORT_CREATED
+	EN	Recently collected
+
+PLUGIN_PYRRHA_STATION_SORT_PLAYED
+	EN	Recently played
+
+PLUGIN_PYRRHA_STATION_SORT_LISTENED
+	EN	Most listened
+
+PLUGIN_PYRRHA_DISABLE_QUICKMIX
+	EN	Disable QuickMix
+
+PLUGIN_PYRRHA_DISABLE_QUICKMIX_DESC
+	EN	Prevent listing the QuickMix station


### PR DESCRIPTION
Uses the REST API for the station list to allow sorting by lastPlayed and totalPlayTime.

Some implementation notes:
  - There is no generic `artUrl` parameter for the stations, rather a list of varying sized art is provided. This chooses the first, which happens to be 90x90 pixels. 130x130, 500x500, 640x640 and 1080x1080 are also available.
  - The 'QuickMix' station is called 'Shuffle' in the REST API. We could override the name back to QuickMix if desired.
  - `stationName` becomes `name` in the station hash
  - The REST API defaults to sorting by 'recently played', but the JSON API appears to default to 'recently created'. This sets the default to 'recently played', but we could set it to 'recently created' if desired.
  - The REST API paginates results. This fetches 250 stations at a time, but that number could be altered if desired.
  - The REST API station list does not include the QuickMix station, so it must be fetched separately.
  - There doesn't appear to be the concept of `stationToken` in the REST API, so the `stationId` => `stationToken` mapping was removed.
  - The 'Shuffle' station can be disabled from appearing in the list in the settings.