### PR TITLE
Issue #34: Provide choice of location -- "My Apps" or "Radio"

### DIFF
--- a/plugin/HTML/EN/plugins/Pyrrha/settings/basic.html
+++ b/plugin/HTML/EN/plugins/Pyrrha/settings/basic.html
@@ -40,4 +40,13 @@
 		<label for="forceNonMaterialIcon">[% "PLUGIN_PYRRHA_FORCE_NONMATERIAL_APPICON" | string %]</label>
 	[% END %]
 
+	[% WRAPPER setting title="PLUGIN_PYRRHA_MENULOCATION" desc="PLUGIN_PYRRHA_MENULOCATION_DESC" %]
+		<div>
+			<select class="stdedit" name="pref_showInRadioMenu" id="showInRadioMenu">
+				<option value="0">[% "PLUGIN_MY_APPS_MODULE_NAME" | string %]</option>
+				<option value="1" [% IF prefs.pref_showInRadioMenu; "selected"; END %]>[% "RADIO" | string %]</option>
+			</select>
+		</div>
+	[% END %]
+
 [% PROCESS settings/footer.html %]

--- a/plugin/Plugin.pm
+++ b/plugin/Plugin.pm
@@ -122,9 +122,9 @@ sub initPlugin {
   $class->SUPER::initPlugin(
     feed   => \&handleFeed,
     tag    => 'pyrrha',
-    menu   => 'music_services',
+    menu   => 'radios',
     weight => 10,
-    is_app => 1,
+    is_app => $prefs->get('showInRadioMenu') ? 0 : 1,
   );
 
   $defaultStationArtUrl = $class->SUPER::_pluginDataFor('icon');

--- a/plugin/Settings.pm
+++ b/plugin/Settings.pm
@@ -16,7 +16,7 @@ sub page {
 }
 
 sub prefs {
-  return ($prefs, 'username', 'password', 'stationSortOrder', 'disableQuickMix', 'forceNonMaterialIcon');
+  return ($prefs, 'username', 'password', 'stationSortOrder', 'disableQuickMix', 'forceNonMaterialIcon', 'showInRadioMenu');
 }
 
 sub handler {

--- a/plugin/strings.txt
+++ b/plugin/strings.txt
@@ -106,3 +106,13 @@ PLUGIN_PYRRHA_DISABLE_QUICKMIX
 PLUGIN_PYRRHA_DISABLE_QUICKMIX_DESC
 	EN	Prevent listing the QuickMix station
 	FR	Empêche l'affichage de la station QuickMix
+
+PLUGIN_PYRRHA_MENULOCATION
+	DE	Menüwahl
+	EN	Show in menu
+	FR	Afficher dans le menu
+
+PLUGIN_PYRRHA_MENULOCATION_DESC
+	DE	Wählen Sie, ob das Plugin in "Eigene Anwendungen" oder "Radio" auftauchen soll. Bitte beachten Sie, dass Sie den Server neu starten müssen, um die Änderung zu aktivieren.
+	EN	Select if you want the plugin to appear in "My Apps" or "Radio". Note that you will need to restart the server after changing this setting.
+	FR	Sélectionnez si vous souhaitez que le plugin apparaisse dans le menu "Mes applications" ou "Radio". Notez que vous devrez redémarrer le serveur après avoir modifié ce paramètre.


### PR DESCRIPTION
Allow the user to choose whether the plugin shows up in the "My Apps" section or the "Radio" section of the LMS main menu.

Copied practically verbatim from @michaelherger's recent commit to his "Radio Paradise" plugin:
https://github.com/michaelherger/RadioParadise/commit/a7c3d744cac39ac819fdb99fe26397b7c756ca83
